### PR TITLE
[fix] portfolio search

### DIFF
--- a/src/main/java/com/example/atp_back/portfolio/PortfolioController.java
+++ b/src/main/java/com/example/atp_back/portfolio/PortfolioController.java
@@ -74,24 +74,10 @@ public class PortfolioController {
     portfolioService.viewCnt(portfolioIdx);
   }
 
-  @Operation(summary = "포트폴리오 검색", description = "사용자가 입력한 단어가 포트폴리오의 이름과 같거나 포함된 포트폴리오 목록을 조회")
-  @GetMapping("/search/pname")
-  public ResponseEntity<BaseResponse<PortfolioListResp>> searchByPName(String name) {
-    BaseResponse<PortfolioListResp> resp = BaseResponse.success(portfolioService.searchByPName(name));
-    return ResponseEntity.ok(resp);
-  }
-  
-  @Operation(summary = "포트폴리오 검색", description = "사용자가 입력한 단어가 다른 사용자의 이름과 같거나 포함된 포트폴리오 목록을 조회.")
-  @GetMapping("/search/uname")
-  public ResponseEntity<BaseResponse<PortfolioListResp>> searchByUName(String name) {
-    BaseResponse<PortfolioListResp> resp = BaseResponse.success(portfolioService.searchByUName(name));
-    return ResponseEntity.ok(resp);
-  }
-
-  @Operation(summary = "포트폴리오 검색", description = "사용자가 입력한 단어가 주식 이름과 같거나 포함된 포트폴리오 목록을 조회.")
-  @GetMapping("/search/sname")
-  public ResponseEntity<BaseResponse<PortfolioListResp>> searchBySName(String name) {
-    BaseResponse<PortfolioListResp> resp = BaseResponse.success(portfolioService.searchBySName(name));
+  @Operation(summary = "포트폴리오 검색", description = "사용자가 입력한 단어가 포트폴리오의 이름, 주식 이름, 사용자 이름 중 하나라도 일치하는 포트폴리오의 목록을 조회")
+  @GetMapping("/search/{keyword}")
+  public ResponseEntity<BaseResponse<PortfolioListResp>> searchByKeyword(@PathVariable String keyword) {
+    BaseResponse<PortfolioListResp> resp = BaseResponse.success(portfolioService.searchByKeyword(keyword));
     return ResponseEntity.ok(resp);
   }
 

--- a/src/main/java/com/example/atp_back/portfolio/repository/PortfolioCustomRepository.java
+++ b/src/main/java/com/example/atp_back/portfolio/repository/PortfolioCustomRepository.java
@@ -11,11 +11,9 @@ import org.springframework.data.domain.Slice;
 import java.util.List;
 
 public interface PortfolioCustomRepository {
-  //검색 관련
-  List<Portfolio> findAllByNameContaining(String name);
-  List<Portfolio> findAllByUserNameContaining(String name);
-  List<Portfolio> findAllByStockNameContaining(String name);
-
+  //포트폴리오 검색
+  List<Portfolio> searchAllByKeyword(String keyword);
+ 
   //메인 페이지에서 북마크순으로 정렬
   Page<Portfolio> findAllByOrderByBookmarksDesc(Pageable pageable);
 

--- a/src/main/java/com/example/atp_back/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/example/atp_back/portfolio/service/PortfolioService.java
@@ -69,19 +69,9 @@ public class PortfolioService {
         return PortfolioInstanceResp.fromDetail(portfolio);
     }
 
-    /*포트폴리오 검색 관련*/
-    public PortfolioListResp searchByPName(String name) {
-        List<Portfolio> portfolioList = portfolioRepository.findAllByNameContaining(name);
-        return PortfolioListResp.from(null, portfolioList);
-    }
-
-    public PortfolioListResp searchByUName(String name) {
-        List<Portfolio> portfolioList = portfolioRepository.findAllByUserNameContaining(name);
-        return PortfolioListResp.from(null, portfolioList);
-    }
-
-    public PortfolioListResp searchBySName(String name) {
-        List<Portfolio> portfolioList = portfolioRepository.findAllByStockNameContaining(name);
+    /*포트폴리오 검색*/
+    public PortfolioListResp searchByKeyword(String keyword) {
+        List<Portfolio> portfolioList = portfolioRepository.searchAllByKeyword(keyword);
         return PortfolioListResp.from(null, portfolioList);
     }
 


### PR DESCRIPTION
포트폴리오 이름, 유저 이름, 주식 이름으로 분리되어있던 검색 기능을 검색하려는 keyword를 가지고 있으면 전부 반환하도록 수정

#10 

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

프론트에 검색 타입 구분이 없으므로 포트폴리오 이름, 유저 이름, 주식 이름으로 분리되어있던 검색 기능을 어느 하나라도 가지고 있으면 전부 반환하도록 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).